### PR TITLE
FIX: QueryProvider CreateQuery (non-generic) not working

### DIFF
--- a/tests/LinqToSalesforce.CsharpTests/LinqToSalesforce.CsharpTests.csproj
+++ b/tests/LinqToSalesforce.CsharpTests/LinqToSalesforce.CsharpTests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="FakeQueryContext.cs" />
     <Compile Include="Models.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryProviderTests.cs" />
     <Compile Include="TranslationTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/LinqToSalesforce.CsharpTests/QueryProviderTests.cs
+++ b/tests/LinqToSalesforce.CsharpTests/QueryProviderTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace LinqToSalesforce.CsharpTests
+{
+    [TestFixture]
+    public class QueryProviderTests
+    {
+        [Test]
+        public void QueryProvider_WhenSelectCustomerWhereFirstnameIsPopo_SelectQuery()
+        {
+            var context = new FakeQueryContext(() => new List<Customer>());
+
+            // Prepare query expression
+            var customers = context.GetTable<Customer>();
+            var queryExpr = customers.Where(x => x.Firstname == "popo").Expression;
+            
+            // Execute query expression
+            var provider = new QueryProvider(context, "Customer");
+            var query = (provider as IQueryProvider).CreateQuery(queryExpr);
+
+            // Asset
+            Assert.AreEqual("SELECT  FROM Customer WHERE Firstname = 'popo'", query.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Issue:
I've been integrating the extension library with OData interface (using ODataQuerySettings.ApplyTo method). The nature of this approach invokes non-generic version of QueryProvider.CreateQuery operation.

Actual:
QueryProvider crashes in multiple places while executing CreateQuery.

Expected:
QueryProvider.CreateQuery does not break.