### PR TITLE
Provide a direct link to the MyGet Feed Url for Paket/Nuget use

### DIFF
--- a/docs/content/using_type_provider.fsx
+++ b/docs/content/using_type_provider.fsx
@@ -14,8 +14,7 @@
 Using F# type provider
 ======================
 
-For the moment, the NugGet is only on my feed.
-MyGet.org
+For the moment, the NugGet is only on my personal MyGet feed, which can be used as a package source: https://www.myget.org/F/romcyber/api/v2
 
 <div class="row">
   <div class="span1"></div>


### PR DESCRIPTION
I'm using this in my `paket.dependencies` like so:

```
source https://www.nuget.org/api/v2
source https://www.myget.org/F/romcyber/api/v2

framework: net462

nuget Salesforce.TypeProvider
```